### PR TITLE
fix: archive dead sessions and improve stall diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ Important runtime notes:
 - If auto-discovery fails, pass `mgba_path` in `mgba_live_start` or
   `mgba_live_start_with_lua`.
 - Runtime state is stored at `~/.mgba-live-mcp/runtime` (sessions, logs, command/response files).
+- Dead or crashed session directories are moved to
+  `~/.mgba-live-mcp/runtime/archived_sessions/` instead of being deleted.
+- Archived sessions are not treated as active and are not returned by `mgba_live_status` calls.
 - This is a hard cutover from repo-local `.runtime`; no hybrid fallback is used.
 - If you have old repo-local sessions, migrate manually by copying `.runtime/*` to
   `~/.mgba-live-mcp/runtime/`.

--- a/scripts/lua_templates/README.md
+++ b/scripts/lua_templates/README.md
@@ -7,7 +7,7 @@ Reusable Lua templates for `mgba_live_run_lua`.
 Use the `file` argument with an absolute path (recommended):
 
 ```json
-{"session":"<session-id>","file":"/Users/jongseunglim/Documents/mgba-live-mcp/scripts/lua_templates/kamaitachi_fresh_start_to_help_info_page1.lua"}
+{"session":"<session-id>","file":"/absolute/path/to/mgba-live-mcp/scripts/lua_templates/kamaitachi_fresh_start_to_help_info_page1.lua"}
 ```
 
 ## Templates

--- a/src/mgba_live_mcp/live_cli.py
+++ b/src/mgba_live_mcp/live_cli.py
@@ -11,6 +11,7 @@ import argparse
 import base64
 import json
 import os
+import re
 import shutil
 import signal
 import subprocess
@@ -26,6 +27,7 @@ PACKAGE_DIR = MODULE_PATH.parent
 BRIDGE_SCRIPT = PACKAGE_DIR / "resources" / "mgba_live_bridge.lua"
 RUNTIME_ROOT = Path.home() / ".mgba-live-mcp" / "runtime"
 SESSIONS_DIR = RUNTIME_ROOT / "sessions"
+ARCHIVED_SESSIONS_DIR = RUNTIME_ROOT / "archived_sessions"
 ACTIVE_SESSION_FILE = RUNTIME_ROOT / "active_session"
 
 
@@ -74,6 +76,7 @@ def to_lua_value(value: Any) -> str:
 
 def ensure_runtime_dirs() -> None:
     SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
+    ARCHIVED_SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def session_dir(session_id: str) -> Path:
@@ -82,6 +85,18 @@ def session_dir(session_id: str) -> Path:
 
 def session_file(session_id: str) -> Path:
     return session_dir(session_id) / "session.json"
+
+
+def archive_session_destination(session_id: str) -> Path:
+    stamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
+    base = ARCHIVED_SESSIONS_DIR / f"{session_id}-{stamp}"
+    if not base.exists():
+        return base
+    for idx in range(1, 1000):
+        candidate = ARCHIVED_SESSIONS_DIR / f"{session_id}-{stamp}-{idx}"
+        if not candidate.exists():
+            return candidate
+    raise RuntimeError(f"Unable to allocate archive destination for session: {session_id}")
 
 
 def load_session(session_id: str) -> dict[str, Any]:
@@ -148,6 +163,8 @@ def prune_dead_sessions() -> list[str]:
         _refresh_active_session()
         return removed
 
+    ARCHIVED_SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
+
     for candidate in SESSIONS_DIR.glob("*/session.json"):
         try:
             session = json.loads(candidate.read_text())
@@ -160,7 +177,8 @@ def prune_dead_sessions() -> list[str]:
 
         session_id = str(session.get("id") or candidate.parent.name)
         try:
-            shutil.rmtree(candidate.parent)
+            archived = archive_session_destination(session_id)
+            shutil.move(str(candidate.parent), str(archived))
             removed.append(session_id)
         except OSError:
             continue
@@ -228,6 +246,15 @@ def write_command(command_path: Path, command: dict[str, Any]) -> None:
     tmp_path.replace(command_path)
 
 
+def command_file_matches_request_id(command_path: Path, request_id: str) -> bool:
+    try:
+        lua_doc = command_path.read_text()
+    except OSError:
+        return False
+    pattern = rf'\bid\s*=\s*"{re.escape(request_id)}"'
+    return re.search(pattern, lua_doc) is not None
+
+
 def send_command(
     session: dict[str, Any], kind: str, payload: dict[str, Any] | None = None, timeout: float = 10.0
 ) -> dict[str, Any]:
@@ -262,6 +289,11 @@ def send_command(
                 continue
             return response
         time.sleep(0.02)
+    if command_path.exists() and command_file_matches_request_id(command_path, request_id):
+        try:
+            command_path.unlink()
+        except OSError:
+            pass
     raise TimeoutError(f"Timed out waiting for response to command '{kind}'.")
 
 

--- a/src/mgba_live_mcp/server.py
+++ b/src/mgba_live_mcp/server.py
@@ -6,6 +6,7 @@ import asyncio
 import base64
 import binascii
 import json
+import time
 from pathlib import Path
 from typing import Any
 
@@ -17,6 +18,18 @@ from .live_controller import LiveControllerClient
 
 server = Server("mgba-live-mcp")
 _controller = LiveControllerClient()
+_TIMEOUT_FLAG_COMMANDS = {
+    "run-lua",
+    "input-tap",
+    "input-set",
+    "input-clear",
+    "screenshot",
+    "read-memory",
+    "read-range",
+    "dump-pointers",
+    "dump-oam",
+    "dump-entities",
+}
 
 
 def _text_content(payload: Any) -> TextContent:
@@ -108,6 +121,119 @@ def _session_arg_value(command_args: list[str]) -> str | None:
         if value == "--session" and index + 1 < len(command_args):
             return str(command_args[index + 1])
     return None
+
+
+def _append_cli_timeout(command: str, command_args: list[str], timeout: float) -> list[str]:
+    if command not in _TIMEOUT_FLAG_COMMANDS:
+        return list(command_args)
+    if "--timeout" in command_args:
+        return list(command_args)
+    timeout_value = max(float(timeout), 0.0)
+    return [*command_args, "--timeout", f"{timeout_value:g}"]
+
+
+def _looks_like_stall_error(exc: Exception) -> bool:
+    msg = str(exc).lower()
+    return (
+        "timed out" in msg
+        or "bridge is busy" in msg
+        or "command.lua still present" in msg
+        or "no response from bridge" in msg
+    )
+
+
+async def _collect_stall_diagnostics(*, session_id: str, timeout: float) -> dict[str, Any]:
+    diagnostics: dict[str, Any] = {"session_id": session_id}
+    try:
+        status_result = await _controller.run(
+            "status",
+            ["--session", str(session_id)],
+            timeout=max(timeout, 20.0),
+        )
+    except Exception as exc:
+        diagnostics["status_error"] = str(exc)
+        return diagnostics
+
+    payload = status_result.payload
+    status_payload: dict[str, Any] | None = None
+    if isinstance(payload, dict):
+        status_payload = payload
+    elif isinstance(payload, list):
+        for item in payload:
+            if (
+                isinstance(item, dict)
+                and isinstance(item.get("session_id"), str)
+                and item.get("session_id") == session_id
+            ):
+                status_payload = item
+                break
+        if status_payload is None:
+            diagnostics["alive"] = False
+            diagnostics["status_missing_session"] = True
+            return diagnostics
+    else:
+        return diagnostics
+
+    status_session_id = status_payload.get("session_id")
+    if isinstance(status_session_id, str) and status_session_id:
+        diagnostics["status_session_id"] = status_session_id
+        if status_session_id != session_id:
+            diagnostics["status_session_mismatch"] = True
+            diagnostics["alive"] = False
+            return diagnostics
+
+    alive = status_payload.get("alive")
+    if isinstance(alive, bool):
+        diagnostics["alive"] = alive
+
+    heartbeat = status_payload.get("heartbeat")
+    if isinstance(heartbeat, dict):
+        frame = heartbeat.get("frame")
+        if isinstance(frame, (int, float)) and not isinstance(frame, bool):
+            diagnostics["heartbeat_frame"] = int(frame)
+        hb_unix_time = heartbeat.get("unix_time")
+        if isinstance(hb_unix_time, (int, float)) and not isinstance(hb_unix_time, bool):
+            hb_unix = int(hb_unix_time)
+            diagnostics["heartbeat_unix_time"] = hb_unix
+            diagnostics["heartbeat_age_seconds"] = max(0, int(time.time()) - hb_unix)
+    return diagnostics
+
+
+def _format_stall_error_message(
+    *,
+    operation: str,
+    diagnostics: dict[str, Any],
+    original_error: Exception,
+) -> str:
+    details = [f"session_id={diagnostics.get('session_id', 'unknown')}"]
+    if "alive" in diagnostics:
+        details.append(f"alive={diagnostics['alive']}")
+    if "heartbeat_frame" in diagnostics:
+        details.append(f"heartbeat_frame={diagnostics['heartbeat_frame']}")
+    if "heartbeat_age_seconds" in diagnostics:
+        details.append(f"heartbeat_age_seconds={diagnostics['heartbeat_age_seconds']}")
+    if "status_error" in diagnostics:
+        details.append(f"status_error={diagnostics['status_error']}")
+    if "status_session_id" in diagnostics:
+        details.append(f"status_session_id={diagnostics['status_session_id']}")
+    if "status_session_mismatch" in diagnostics:
+        details.append(f"status_session_mismatch={diagnostics['status_session_mismatch']}")
+    if "status_missing_session" in diagnostics:
+        details.append(f"status_missing_session={diagnostics['status_missing_session']}")
+    details.append(f"original_error={original_error}")
+    return (
+        f"{operation}. The session appears stuck. "
+        "Possible causes: bad ROM build/patch, Lua script deadloop, or paused emulation. "
+        f"Diagnostics: {', '.join(details)}"
+    )
+
+
+def _append_warning(payload: dict[str, Any], warning: dict[str, Any]) -> None:
+    warnings = payload.get("warnings")
+    if not isinstance(warnings, list):
+        warnings = []
+        payload["warnings"] = warnings
+    warnings.append(warning)
 
 
 async def _resolve_snapshot_session(
@@ -211,9 +337,14 @@ async def _wait_for_macro_completion(
 
     while True:
         polls += 1
-        poll_result = await _controller.run(
+        poll_args = _append_cli_timeout(
             "run-lua",
             ["--code", wait_code, "--session", str(session_id)],
+            poll_command_timeout,
+        )
+        poll_result = await _controller.run(
+            "run-lua",
+            poll_args,
             timeout=poll_command_timeout,
         )
         result_value = _extract_run_lua_result(poll_result.payload)
@@ -252,9 +383,14 @@ async def _wait_for_target_frame(
     poll_command_timeout = max(1.0, min(5.0, settle_timeout if settle_timeout > 0 else 1.0))
 
     while True:
-        poll_result = await _controller.run(
+        poll_args = _append_cli_timeout(
             "run-lua",
             ["--code", "return true", "--session", str(session_id)],
+            poll_command_timeout,
+        )
+        poll_result = await _controller.run(
+            "run-lua",
+            poll_args,
             timeout=poll_command_timeout,
         )
         current_frame = _extract_response_frame(poll_result.payload)
@@ -284,7 +420,24 @@ async def _run_with_snapshot(
     require_screenshot: bool = False,
     input_tap_wait_frames: int | None = None,
 ) -> list[TextContent | ImageContent]:
-    command_result = await _controller.run(live_command, command_args, timeout=timeout)
+    run_command_args = _append_cli_timeout(live_command, command_args, timeout)
+    requested_session = session_id or _session_arg_value(run_command_args)
+    try:
+        command_result = await _controller.run(live_command, run_command_args, timeout=timeout)
+    except Exception as exc:
+        if requested_session and _looks_like_stall_error(exc):
+            diagnostics = await _collect_stall_diagnostics(
+                session_id=str(requested_session),
+                timeout=max(timeout, 20.0),
+            )
+            raise RuntimeError(
+                _format_stall_error_message(
+                    operation=f"Live command '{live_command}' failed",
+                    diagnostics=diagnostics,
+                    original_error=exc,
+                )
+            ) from exc
+        raise
     payload: dict[str, Any]
     if isinstance(command_result.payload, dict):
         payload = dict(command_result.payload)
@@ -296,13 +449,13 @@ async def _run_with_snapshot(
         return [_text_content(payload)]
 
     resolved_session = session_id or await _resolve_snapshot_session(
-        command_args,
+        run_command_args,
         command_result.payload,
         timeout=timeout,
     )
     if not resolved_session:
         if require_snapshot_session:
-            requested_session = session_id or _session_arg_value(command_args) or "unknown"
+            requested_session = session_id or _session_arg_value(run_command_args) or "unknown"
             raise RuntimeError(
                 f"Unable to resolve session_id for screenshot capture after '{live_command}' "
                 f"(requested_session={requested_session})."
@@ -324,9 +477,19 @@ async def _run_with_snapshot(
                 timeout=max(timeout, 20.0),
             )
         except Exception as exc:
+            diagnostics = await _collect_stall_diagnostics(
+                session_id=str(resolved_session),
+                timeout=max(timeout, 20.0),
+            )
             raise RuntimeError(
-                f"Post-tap wait failed for session '{resolved_session}' "
-                f"(target_frame={target_frame}). Original error: {exc}"
+                _format_stall_error_message(
+                    operation=(
+                        f"Post-tap wait failed for session '{resolved_session}' "
+                        f"(target_frame={target_frame})"
+                    ),
+                    diagnostics=diagnostics,
+                    original_error=exc,
+                )
             ) from exc
 
     if ensure_post_lua_settle:
@@ -338,23 +501,69 @@ async def _run_with_snapshot(
                     macro_key=macro_key,
                     timeout=max(timeout, 20.0),
                 )
-            except Exception:
-                pass
+            except Exception as exc:
+                diagnostics = await _collect_stall_diagnostics(
+                    session_id=str(resolved_session),
+                    timeout=max(timeout, 20.0),
+                )
+                _append_warning(
+                    payload,
+                    {
+                        "code": "post_lua_macro_settle_failed",
+                        "message": _format_stall_error_message(
+                            operation=(
+                                f"Post-Lua macro settle failed for session '{resolved_session}' "
+                                f"(macro_key={macro_key})"
+                            ),
+                            diagnostics=diagnostics,
+                            original_error=exc,
+                        ),
+                        **diagnostics,
+                    },
+                )
         else:
             # For run-lua calls, issue a no-op Lua command before screenshot capture
             # so the image reflects state after the Lua command has fully completed.
             try:
-                await _controller.run(
+                settle_timeout = max(timeout, 20.0)
+                settle_args = _append_cli_timeout(
                     "run-lua",
                     ["--code", "return true", "--session", str(resolved_session)],
+                    settle_timeout,
+                )
+                await _controller.run(
+                    "run-lua",
+                    settle_args,
+                    timeout=settle_timeout,
+                )
+            except Exception as exc:
+                diagnostics = await _collect_stall_diagnostics(
+                    session_id=str(resolved_session),
                     timeout=max(timeout, 20.0),
                 )
-            except Exception:
-                pass
+                _append_warning(
+                    payload,
+                    {
+                        "code": "post_lua_noop_settle_failed",
+                        "message": _format_stall_error_message(
+                            operation=(
+                                f"Post-Lua no-op settle failed for session '{resolved_session}'"
+                            ),
+                            diagnostics=diagnostics,
+                            original_error=exc,
+                        ),
+                        **diagnostics,
+                    },
+                )
 
-    shot_args = ["--session", str(resolved_session), "--no-save"]
+    screenshot_timeout = max(timeout, 20.0)
+    shot_args = _append_cli_timeout(
+        "screenshot",
+        ["--session", str(resolved_session), "--no-save"],
+        screenshot_timeout,
+    )
     try:
-        shot_result = await _controller.run("screenshot", shot_args, timeout=max(timeout, 20.0))
+        shot_result = await _controller.run("screenshot", shot_args, timeout=screenshot_timeout)
         screenshot_payload = shot_result.payload
         public_snapshot = (
             _public_snapshot_payload(screenshot_payload)
@@ -884,7 +1093,8 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent | 
         if out := args.get("out"):
             cmd_args.extend(["--out", str(out)])
         cmd_args.extend(_build_session_arg(args))
-        command_result = await _controller.run("screenshot", cmd_args, timeout=timeout)
+        run_args = _append_cli_timeout("screenshot", cmd_args, timeout)
+        command_result = await _controller.run("screenshot", run_args, timeout=timeout)
         payload: dict[str, Any]
         if isinstance(command_result.payload, dict):
             payload = dict(command_result.payload)

--- a/tests/test_export_screenshot_tool.py
+++ b/tests/test_export_screenshot_tool.py
@@ -54,7 +54,7 @@ def test_export_screenshot_tool_maps_to_screenshot_command(monkeypatch: Any) -> 
     assert fake.calls == [
         {
             "command": "screenshot",
-            "args": ["--session", "session-123"],
+            "args": ["--session", "session-123", "--timeout", "9"],
             "timeout": 9.0,
         }
     ]
@@ -132,5 +132,9 @@ def test_status_all_uses_session_from_payload_for_snapshot(monkeypatch: Any) -> 
     assert payload["screenshot"] == {"frame": 200}
     assert fake.calls == [
         {"command": "status", "args": ["--all"], "timeout": 20.0},
-        {"command": "screenshot", "args": ["--session", "session-a", "--no-save"], "timeout": 20.0},
+        {
+            "command": "screenshot",
+            "args": ["--session", "session-a", "--no-save", "--timeout", "20"],
+            "timeout": 20.0,
+        },
     ]

--- a/tests/test_input_tap_snapshot.py
+++ b/tests/test_input_tap_snapshot.py
@@ -96,11 +96,47 @@ def test_input_tap_waits_after_release_then_returns_screenshot(monkeypatch: Any)
         "run-lua",
         "screenshot",
     ]
-    assert fake.calls[0]["args"] == ["--key", "A", "--frames", "3", "--session", "session-123"]
-    assert fake.calls[1]["args"] == ["--code", "return true", "--session", "session-123"]
-    assert fake.calls[2]["args"] == ["--code", "return true", "--session", "session-123"]
-    assert fake.calls[3]["args"] == ["--code", "return true", "--session", "session-123"]
-    assert fake.calls[4]["args"] == ["--session", "session-123", "--no-save"]
+    assert fake.calls[0]["args"] == [
+        "--key",
+        "A",
+        "--frames",
+        "3",
+        "--session",
+        "session-123",
+        "--timeout",
+        "7",
+    ]
+    assert fake.calls[1]["args"] == [
+        "--code",
+        "return true",
+        "--session",
+        "session-123",
+        "--timeout",
+        "5",
+    ]
+    assert fake.calls[2]["args"] == [
+        "--code",
+        "return true",
+        "--session",
+        "session-123",
+        "--timeout",
+        "5",
+    ]
+    assert fake.calls[3]["args"] == [
+        "--code",
+        "return true",
+        "--session",
+        "session-123",
+        "--timeout",
+        "5",
+    ]
+    assert fake.calls[4]["args"] == [
+        "--session",
+        "session-123",
+        "--no-save",
+        "--timeout",
+        "20",
+    ]
 
 
 def test_input_tap_wait_frames_zero_still_waits_through_tap_duration(monkeypatch: Any) -> None:
@@ -158,7 +194,7 @@ def test_input_tap_wait_failure_includes_session_id(monkeypatch: Any) -> None:
                 },
             )
         )
-    assert [call["command"] for call in fake.calls] == ["input-tap", "run-lua"]
+    assert [call["command"] for call in fake.calls] == ["input-tap", "run-lua", "status"]
 
 
 def test_input_tap_errors_when_session_cannot_be_resolved(monkeypatch: Any) -> None:

--- a/tests/test_live_cli_branch_coverage.py
+++ b/tests/test_live_cli_branch_coverage.py
@@ -21,9 +21,11 @@ def _ns(**kwargs: Any) -> argparse.Namespace:
 def isolated_runtime(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> tuple[Path, Path, Path]:
     runtime = tmp_path / "runtime"
     sessions_dir = runtime / "sessions"
+    archived_sessions_dir = runtime / "archived_sessions"
     active_file = runtime / "active_session"
     monkeypatch.setattr(live_cli, "RUNTIME_ROOT", runtime)
     monkeypatch.setattr(live_cli, "SESSIONS_DIR", sessions_dir)
+    monkeypatch.setattr(live_cli, "ARCHIVED_SESSIONS_DIR", archived_sessions_dir)
     monkeypatch.setattr(live_cli, "ACTIVE_SESSION_FILE", active_file)
     return runtime, sessions_dir, active_file
 
@@ -135,7 +137,7 @@ def test_prune_dead_sessions_handles_removal_errors(
 
     monkeypatch.setattr(live_cli, "pid_alive", lambda _pid: False)
     monkeypatch.setattr(
-        live_cli.shutil, "rmtree", lambda _path: (_ for _ in ()).throw(OSError("x"))
+        live_cli.shutil, "move", lambda _src, _dst: (_ for _ in ()).throw(OSError("x"))
     )
     removed = live_cli.prune_dead_sessions()
     assert removed == []
@@ -259,6 +261,47 @@ def test_send_command_busy_and_response_timeouts(tmp_path: Path) -> None:
     command_path.unlink()
     with pytest.raises(TimeoutError, match="Timed out waiting for response"):
         live_cli.send_command(session, "ping", timeout=0.05)
+
+
+def test_command_file_matches_request_id_missing_file(tmp_path: Path) -> None:
+    assert live_cli.command_file_matches_request_id(tmp_path / "missing.lua", "req-1") is False
+
+
+def test_send_command_timeout_cleans_owned_command_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    command_path = tmp_path / "command.lua"
+    response_path = tmp_path / "response.json"
+    session = {"command_path": str(command_path), "response_path": str(response_path)}
+
+    class _U:
+        hex = "req-owned"
+
+    monkeypatch.setattr(live_cli.uuid, "uuid4", lambda: _U())
+
+    with pytest.raises(TimeoutError, match="Timed out waiting for response"):
+        live_cli.send_command(session, "ping", timeout=0.05)
+
+    assert command_path.exists() is False
+
+
+def test_send_command_timeout_preserves_foreign_command_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    command_path = tmp_path / "command.lua"
+    response_path = tmp_path / "response.json"
+    session = {"command_path": str(command_path), "response_path": str(response_path)}
+
+    class _U:
+        hex = "req-foreign"
+
+    monkeypatch.setattr(live_cli.uuid, "uuid4", lambda: _U())
+    monkeypatch.setattr(live_cli, "command_file_matches_request_id", lambda *_args: False)
+
+    with pytest.raises(TimeoutError, match="Timed out waiting for response"):
+        live_cli.send_command(session, "ping", timeout=0.05)
+
+    assert command_path.exists() is True
 
 
 def test_print_json_output(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_run_lua_snapshot.py
+++ b/tests/test_run_lua_snapshot.py
@@ -66,10 +66,23 @@ def test_run_lua_snapshot_uses_status_fallback_when_session_not_provided(monkeyp
         "run-lua",
         "screenshot",
     ]
-    assert fake.calls[0]["args"] == ["--code", "return 7"]
+    assert fake.calls[0]["args"] == ["--code", "return 7", "--timeout", "7"]
     assert fake.calls[1]["args"] == []
-    assert fake.calls[2]["args"] == ["--code", "return true", "--session", "active-session"]
-    assert fake.calls[3]["args"] == ["--session", "active-session", "--no-save"]
+    assert fake.calls[2]["args"] == [
+        "--code",
+        "return true",
+        "--session",
+        "active-session",
+        "--timeout",
+        "20",
+    ]
+    assert fake.calls[3]["args"] == [
+        "--session",
+        "active-session",
+        "--no-save",
+        "--timeout",
+        "20",
+    ]
     assert fake.calls[0]["timeout"] == 7.0
     assert fake.calls[1]["timeout"] == 20.0
     assert fake.calls[2]["timeout"] == 20.0
@@ -94,9 +107,29 @@ def test_run_lua_snapshot_settles_before_screenshot_when_session_is_given(monkey
 
     assert payload["screenshot"] == {"frame": 102}
     assert [call["command"] for call in fake.calls] == ["run-lua", "run-lua", "screenshot"]
-    assert fake.calls[0]["args"] == ["--code", "return 9", "--session", "session-123"]
-    assert fake.calls[1]["args"] == ["--code", "return true", "--session", "session-123"]
-    assert fake.calls[2]["args"] == ["--session", "session-123", "--no-save"]
+    assert fake.calls[0]["args"] == [
+        "--code",
+        "return 9",
+        "--session",
+        "session-123",
+        "--timeout",
+        "5",
+    ]
+    assert fake.calls[1]["args"] == [
+        "--code",
+        "return true",
+        "--session",
+        "session-123",
+        "--timeout",
+        "20",
+    ]
+    assert fake.calls[2]["args"] == [
+        "--session",
+        "session-123",
+        "--no-save",
+        "--timeout",
+        "20",
+    ]
 
 
 def test_run_lua_snapshot_waits_for_macro_completion_when_macro_key_returned(
@@ -152,5 +185,12 @@ def test_run_lua_snapshot_waits_for_macro_completion_when_macro_key_returned(
         "run-lua",
         "screenshot",
     ]
-    assert fake.calls[0]["args"] == ["--code", "return 11", "--session", "session-123"]
+    assert fake.calls[0]["args"] == [
+        "--code",
+        "return 11",
+        "--session",
+        "session-123",
+        "--timeout",
+        "5",
+    ]
     assert "__macro_wait_test" in fake.calls[1]["args"][1]

--- a/tests/test_server_branch_coverage.py
+++ b/tests/test_server_branch_coverage.py
@@ -134,6 +134,7 @@ async def test_run_with_snapshot_edge_paths(monkeypatch: pytest.MonkeyPatch) -> 
         [
             {"data": {"result": {"macro_key": "macro1"}}},
             {},
+            {},
         ]
     )
     monkeypatch.setattr(server, "_controller", queue)
@@ -151,6 +152,7 @@ async def test_run_with_snapshot_edge_paths(monkeypatch: pytest.MonkeyPatch) -> 
         [
             {"data": {"result": {"value": 1}}},
             RuntimeError("no-op failed"),
+            {},
             {},
         ]
     )
@@ -179,6 +181,37 @@ async def test_run_with_snapshot_edge_paths(monkeypatch: pytest.MonkeyPatch) -> 
             session_id="s1",
             require_screenshot=True,
         )
+
+
+@pytest.mark.anyio
+async def test_run_with_snapshot_wraps_stall_errors_with_diagnostics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queue = _QueueController(
+        [
+            TimeoutError("Timed out waiting for response to command 'run_lua'"),
+            {
+                "session_id": "other-session",
+                "alive": True,
+                "heartbeat": {"frame": 77, "unix_time": 123},
+            },
+        ]
+    )
+    monkeypatch.setattr(server, "_controller", queue)
+
+    with pytest.raises(RuntimeError, match="The session appears stuck") as exc_info:
+        await server._run_with_snapshot(
+            "run-lua",
+            ["--code", "return 1", "--session", "requested-session"],
+            timeout=1.0,
+            include_snapshot=False,
+        )
+
+    message = str(exc_info.value)
+    assert "bad ROM build/patch" in message
+    assert "session_id=requested-session" in message
+    assert "status_session_mismatch=True" in message
+    assert [call[0] for call in queue.calls] == ["run-lua", "status"]
 
 
 def test_build_start_command_args_edges() -> None:

--- a/tests/test_start_script_flag.py
+++ b/tests/test_start_script_flag.py
@@ -140,6 +140,7 @@ def test_cmd_start_passes_startup_script_to_mgba_process(tmp_path: Path, monkeyp
     runtime_root = tmp_path / ".runtime"
     monkeypatch.setattr(mgba_live, "RUNTIME_ROOT", runtime_root)
     monkeypatch.setattr(mgba_live, "SESSIONS_DIR", runtime_root / "sessions")
+    monkeypatch.setattr(mgba_live, "ARCHIVED_SESSIONS_DIR", runtime_root / "archived_sessions")
     monkeypatch.setattr(mgba_live, "ACTIVE_SESSION_FILE", runtime_root / "active_session")
 
     captured: dict[str, Any] = {}
@@ -319,9 +320,23 @@ def test_mcp_start_with_lua_file_mode_runs_start_lua_and_screenshot(monkeypatch:
     assert payload["lua"] == {"ok": True}
     assert payload["screenshot"] == {"frame": 102}
     assert [call["command"] for call in fake.calls] == ["start", "run-lua", "run-lua", "screenshot"]
-    assert fake.calls[1]["args"] == ["--file", "/tmp/startup.lua", "--session", "session-123"]
-    assert fake.calls[2]["args"] == ["--code", "return true", "--session", "session-123"]
-    assert fake.calls[3]["args"] == ["--session", "session-123", "--no-save"]
+    assert fake.calls[1]["args"] == [
+        "--file",
+        "/tmp/startup.lua",
+        "--session",
+        "session-123",
+        "--timeout",
+        "7",
+    ]
+    assert fake.calls[2]["args"] == [
+        "--code",
+        "return true",
+        "--session",
+        "session-123",
+        "--timeout",
+        "20",
+    ]
+    assert fake.calls[3]["args"] == ["--session", "session-123", "--no-save", "--timeout", "20"]
 
 
 def test_mcp_start_with_lua_code_mode_runs_start_lua_and_screenshot(monkeypatch: Any) -> None:
@@ -345,7 +360,14 @@ def test_mcp_start_with_lua_code_mode_runs_start_lua_and_screenshot(monkeypatch:
     assert payload["lua"] == {"ok": True}
     assert payload["screenshot"] == {"frame": 102}
     assert [call["command"] for call in fake.calls] == ["start", "run-lua", "run-lua", "screenshot"]
-    assert fake.calls[1]["args"] == ["--code", "return 77", "--session", "session-123"]
+    assert fake.calls[1]["args"] == [
+        "--code",
+        "return 77",
+        "--session",
+        "session-123",
+        "--timeout",
+        "7",
+    ]
 
 
 def test_mcp_start_with_lua_leaves_session_running_when_lua_step_fails(monkeypatch: Any) -> None:
@@ -389,6 +411,7 @@ def test_cmd_status_all_prunes_dead_sessions(tmp_path: Path, monkeypatch: Any) -
     runtime_root = tmp_path / ".runtime"
     monkeypatch.setattr(mgba_live, "RUNTIME_ROOT", runtime_root)
     monkeypatch.setattr(mgba_live, "SESSIONS_DIR", runtime_root / "sessions")
+    monkeypatch.setattr(mgba_live, "ARCHIVED_SESSIONS_DIR", runtime_root / "archived_sessions")
     monkeypatch.setattr(mgba_live, "ACTIVE_SESSION_FILE", runtime_root / "active_session")
 
     _write_session_fixture(runtime_root, "dead-session", 1001)
@@ -414,6 +437,7 @@ def test_cmd_status_skips_dead_active_session(tmp_path: Path, monkeypatch: Any) 
     runtime_root = tmp_path / ".runtime"
     monkeypatch.setattr(mgba_live, "RUNTIME_ROOT", runtime_root)
     monkeypatch.setattr(mgba_live, "SESSIONS_DIR", runtime_root / "sessions")
+    monkeypatch.setattr(mgba_live, "ARCHIVED_SESSIONS_DIR", runtime_root / "archived_sessions")
     monkeypatch.setattr(mgba_live, "ACTIVE_SESSION_FILE", runtime_root / "active_session")
 
     _write_session_fixture(runtime_root, "dead-session", 2001)
@@ -433,12 +457,13 @@ def test_cmd_status_skips_dead_active_session(tmp_path: Path, monkeypatch: Any) 
     assert mgba_live.ACTIVE_SESSION_FILE.read_text() == "alive-session"
 
 
-def test_prune_dead_sessions_removes_dead_session_directory(
+def test_prune_dead_sessions_archives_dead_session_directory(
     tmp_path: Path, monkeypatch: Any
 ) -> None:
     runtime_root = tmp_path / ".runtime"
     monkeypatch.setattr(mgba_live, "RUNTIME_ROOT", runtime_root)
     monkeypatch.setattr(mgba_live, "SESSIONS_DIR", runtime_root / "sessions")
+    monkeypatch.setattr(mgba_live, "ARCHIVED_SESSIONS_DIR", runtime_root / "archived_sessions")
     monkeypatch.setattr(mgba_live, "ACTIVE_SESSION_FILE", runtime_root / "active_session")
 
     _write_session_fixture(runtime_root, "dead-session", 3001)
@@ -453,6 +478,9 @@ def test_prune_dead_sessions_removes_dead_session_directory(
     assert removed == ["dead-session"]
     assert not (runtime_root / "sessions" / "dead-session").exists()
     assert (runtime_root / "sessions" / "alive-session").exists()
+    archived = sorted((runtime_root / "archived_sessions").glob("dead-session-*"))
+    assert len(archived) == 1
+    assert (archived[0] / "session.json").exists()
     assert mgba_live.ACTIVE_SESSION_FILE.read_text() == "alive-session"
 
 
@@ -463,6 +491,7 @@ def test_prune_dead_sessions_clears_stale_active_pointer_when_no_sessions(
     runtime_root = tmp_path / ".runtime"
     monkeypatch.setattr(mgba_live, "RUNTIME_ROOT", runtime_root)
     monkeypatch.setattr(mgba_live, "SESSIONS_DIR", runtime_root / "sessions")
+    monkeypatch.setattr(mgba_live, "ARCHIVED_SESSIONS_DIR", runtime_root / "archived_sessions")
     monkeypatch.setattr(mgba_live, "ACTIVE_SESSION_FILE", runtime_root / "active_session")
 
     mgba_live.ACTIVE_SESSION_FILE.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- archive dead/crashed session directories to `~/.mgba-live-mcp/runtime/archived_sessions` instead of deleting them
- keep active/session listing behavior unchanged so dead sessions are not treated as active
- add request-id scoped cleanup of stale `command.lua` on response timeout
- improve stalled-session errors with explicit diagnostics and likely-cause hints (including bad ROM/Lua deadloop)
- pass CLI `--timeout` through snapshot/polling code paths for consistency
- add warning payloads when post-Lua settle checks fail but execution continues
- add/expand tests for archive behavior, timeout arg propagation, stall wrapping, and timeout cleanup branches

## Verification
- `make check`
  - ruff format/check: pass
  - ty check: pass
  - pytest: 82 passed
  - mcp docs check: pass

## Notes
- Added a README runtime note clarifying dead-session archival and active status behavior.
