### PR TITLE
chore(release): bump version to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.3.1
+
+- Archive dead/crashed session directories to
+  `~/.mgba-live-mcp/runtime/archived_sessions` instead of deleting them.
+- Keep dead sessions out of active session resolution and status listings.
+- Improve stalled-session errors with explicit diagnostics and likely causes
+  (including bad ROM build/patch and Lua deadloops).
+- Add scoped stale `command.lua` cleanup when a command response times out.
+- Expand test coverage for stall diagnostics, timeout handling, and archive
+  behavior.
+- Remove user-specific absolute path from Lua template README examples.
+
 ## 0.2.0
 
 - Switched live-controller subprocess execution to packaged module invocation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mgba-live-mcp"
-version = "0.3.0"
+version = "0.3.1"
 description = "MCP server for persistent live mGBA control with script bridge, screenshots, memory and input tooling"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/mgba_live_mcp/__init__.py
+++ b/src/mgba_live_mcp/__init__.py
@@ -1,3 +1,3 @@
 """mGBA live MCP package."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/uv.lock
+++ b/uv.lock
@@ -450,7 +450,7 @@ wheels = [
 
 [[package]]
 name = "mgba-live-mcp"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
Release metadata for v0.3.1 (version bump + changelog).