### PR TITLE
[codex] fix unsupported tool parameter schemas

### DIFF
--- a/docs/mcp-reference.md
+++ b/docs/mcp-reference.md
@@ -65,27 +65,15 @@ _Not declared._
 
 Start a live session and run Lua immediately. Metadata only.
 
-- Required input fields: _Conditional; see schema._
+- Required input fields: `rom`
 
 ### Input Schema
 
 ```json
 {
-  "oneOf": [
-    {
-      "required": [
-        "file"
-      ]
-    },
-    {
-      "required": [
-        "code"
-      ]
-    }
-  ],
   "properties": {
     "code": {
-      "description": "Inline Lua code.",
+      "description": "Inline Lua code. Provide exactly one of file or code.",
       "type": "string"
     },
     "fast": {
@@ -93,7 +81,7 @@ Start a live session and run Lua immediately. Metadata only.
       "type": "boolean"
     },
     "file": {
-      "description": "Lua file path.",
+      "description": "Lua file path. Provide exactly one of file or code.",
       "type": "string"
     },
     "fps_target": {
@@ -136,27 +124,15 @@ _Not declared._
 
 Start a live session, run Lua, settle, and return one screenshot.
 
-- Required input fields: _Conditional; see schema._
+- Required input fields: `rom`
 
 ### Input Schema
 
 ```json
 {
-  "oneOf": [
-    {
-      "required": [
-        "file"
-      ]
-    },
-    {
-      "required": [
-        "code"
-      ]
-    }
-  ],
   "properties": {
     "code": {
-      "description": "Inline Lua code.",
+      "description": "Inline Lua code. Provide exactly one of file or code.",
       "type": "string"
     },
     "fast": {
@@ -164,7 +140,7 @@ Start a live session, run Lua, settle, and return one screenshot.
       "type": "boolean"
     },
     "file": {
-      "description": "Lua file path.",
+      "description": "Lua file path. Provide exactly one of file or code.",
       "type": "string"
     },
     "fps_target": {
@@ -207,31 +183,19 @@ _Not declared._
 
 Attach to an existing managed live session.
 
-- Required input fields: _Conditional; see schema._
+- Required input fields: _None._
 
 ### Input Schema
 
 ```json
 {
-  "anyOf": [
-    {
-      "required": [
-        "session"
-      ]
-    },
-    {
-      "required": [
-        "pid"
-      ]
-    }
-  ],
   "properties": {
     "pid": {
-      "description": "PID of a managed session.",
+      "description": "PID of a managed session. Provide session or pid (at least one).",
       "type": "integer"
     },
     "session": {
-      "description": "Session id.",
+      "description": "Session id. Provide session or pid (at least one required).",
       "type": "string"
     },
     "timeout": {
@@ -251,36 +215,19 @@ _Not declared._
 
 Show metadata for one session or all managed sessions.
 
-- Required input fields: _Conditional; see schema._
+- Required input fields: _None._
 
 ### Input Schema
 
 ```json
 {
-  "anyOf": [
-    {
-      "required": [
-        "session"
-      ]
-    },
-    {
-      "properties": {
-        "all": {
-          "const": true
-        }
-      },
-      "required": [
-        "all"
-      ]
-    }
-  ],
   "properties": {
     "all": {
-      "description": "Whether to include all sessions.",
+      "description": "If true, list all sessions. Otherwise pass session.",
       "type": "boolean"
     },
     "session": {
-      "description": "Session id.",
+      "description": "Session id for one session. Or set all=true for every session.",
       "type": "string"
     },
     "timeout": {
@@ -366,31 +313,19 @@ _Not declared._
 
 Execute Lua in a running live session. Metadata only.
 
-- Required input fields: _Conditional; see schema._
+- Required input fields: `session`
 
 ### Input Schema
 
 ```json
 {
-  "oneOf": [
-    {
-      "required": [
-        "file"
-      ]
-    },
-    {
-      "required": [
-        "code"
-      ]
-    }
-  ],
   "properties": {
     "code": {
-      "description": "Inline Lua code.",
+      "description": "Inline Lua code. Provide exactly one of file or code.",
       "type": "string"
     },
     "file": {
-      "description": "Lua file path.",
+      "description": "Lua file path. Provide exactly one of file or code.",
       "type": "string"
     },
     "session": {
@@ -417,31 +352,19 @@ _Not declared._
 
 Execute Lua, settle, and return one screenshot.
 
-- Required input fields: _Conditional; see schema._
+- Required input fields: `session`
 
 ### Input Schema
 
 ```json
 {
-  "oneOf": [
-    {
-      "required": [
-        "file"
-      ]
-    },
-    {
-      "required": [
-        "code"
-      ]
-    }
-  ],
   "properties": {
     "code": {
-      "description": "Inline Lua code.",
+      "description": "Inline Lua code. Provide exactly one of file or code.",
       "type": "string"
     },
     "file": {
-      "description": "Lua file path.",
+      "description": "Lua file path. Provide exactly one of file or code.",
       "type": "string"
     },
     "session": {

--- a/docs/mcp-reference.md
+++ b/docs/mcp-reference.md
@@ -66,6 +66,7 @@ _Not declared._
 Start a live session and run Lua immediately. Metadata only.
 
 - Required input fields: `rom`
+- Runtime argument rule: Provide exactly one of `file` or `code`.
 
 ### Input Schema
 
@@ -125,6 +126,7 @@ _Not declared._
 Start a live session, run Lua, settle, and return one screenshot.
 
 - Required input fields: `rom`
+- Runtime argument rule: Provide exactly one of `file` or `code`.
 
 ### Input Schema
 
@@ -184,6 +186,7 @@ _Not declared._
 Attach to an existing managed live session.
 
 - Required input fields: _None._
+- Runtime argument rule: Provide `session` or `pid`.
 
 ### Input Schema
 
@@ -216,6 +219,7 @@ _Not declared._
 Show metadata for one session or all managed sessions.
 
 - Required input fields: _None._
+- Runtime argument rule: Provide `session`, or set `all=true`.
 
 ### Input Schema
 
@@ -314,6 +318,7 @@ _Not declared._
 Execute Lua in a running live session. Metadata only.
 
 - Required input fields: `session`
+- Runtime argument rule: Provide exactly one of `file` or `code`.
 
 ### Input Schema
 
@@ -353,6 +358,7 @@ _Not declared._
 Execute Lua, settle, and return one screenshot.
 
 - Required input fields: `session`
+- Runtime argument rule: Provide exactly one of `file` or `code`.
 
 ### Input Schema
 

--- a/docs/mcp-reference.md
+++ b/docs/mcp-reference.md
@@ -194,11 +194,11 @@ Attach to an existing managed live session.
 {
   "properties": {
     "pid": {
-      "description": "PID of a managed session. Provide session or pid (at least one).",
+      "description": "PID of a managed session. Provide session or pid.",
       "type": "integer"
     },
     "session": {
-      "description": "Session id. Provide session or pid (at least one required).",
+      "description": "Session id. Provide session or pid.",
       "type": "string"
     },
     "timeout": {
@@ -231,7 +231,7 @@ Show metadata for one session or all managed sessions.
       "type": "boolean"
     },
     "session": {
-      "description": "Session id for one session. Or set all=true for every session.",
+      "description": "Session id for one session. Provide session, or set all=true.",
       "type": "string"
     },
     "timeout": {

--- a/scripts/generate_mcp_reference.py
+++ b/scripts/generate_mcp_reference.py
@@ -14,14 +14,6 @@ from mcp.types import Tool
 from mgba_live_mcp import server as mcp_server
 
 DEFAULT_OUTPUT = Path("docs/mcp-reference.md")
-RUNTIME_ARGUMENT_RULES = {
-    "mgba_live_start_with_lua": "Provide exactly one of `file` or `code`.",
-    "mgba_live_start_with_lua_and_view": "Provide exactly one of `file` or `code`.",
-    "mgba_live_attach": "Provide `session` or `pid`.",
-    "mgba_live_status": "Provide `session`, or set `all=true`.",
-    "mgba_live_run_lua": "Provide exactly one of `file` or `code`.",
-    "mgba_live_run_lua_and_view": "Provide exactly one of `file` or `code`.",
-}
 
 
 def _format_schema(schema: dict[str, Any] | None) -> str:
@@ -53,7 +45,7 @@ def _render_tool_section(tool: Tool) -> str:
     description = str(data.get("description") or "_No description provided._")
     input_schema = data.get("inputSchema")
     output_schema = data.get("outputSchema")
-    runtime_rule = RUNTIME_ARGUMENT_RULES.get(name)
+    runtime_rule = mcp_server.TOOL_RUNTIME_ARGUMENT_RULES.get(name)
     runtime_rule_lines = []
     if runtime_rule is not None:
         runtime_rule_lines = [f"- Runtime argument rule: {runtime_rule}"]

--- a/scripts/generate_mcp_reference.py
+++ b/scripts/generate_mcp_reference.py
@@ -14,6 +14,14 @@ from mcp.types import Tool
 from mgba_live_mcp import server as mcp_server
 
 DEFAULT_OUTPUT = Path("docs/mcp-reference.md")
+RUNTIME_ARGUMENT_RULES = {
+    "mgba_live_start_with_lua": "Provide exactly one of `file` or `code`.",
+    "mgba_live_start_with_lua_and_view": "Provide exactly one of `file` or `code`.",
+    "mgba_live_attach": "Provide `session` or `pid`.",
+    "mgba_live_status": "Provide `session`, or set `all=true`.",
+    "mgba_live_run_lua": "Provide exactly one of `file` or `code`.",
+    "mgba_live_run_lua_and_view": "Provide exactly one of `file` or `code`.",
+}
 
 
 def _format_schema(schema: dict[str, Any] | None) -> str:
@@ -45,6 +53,10 @@ def _render_tool_section(tool: Tool) -> str:
     description = str(data.get("description") or "_No description provided._")
     input_schema = data.get("inputSchema")
     output_schema = data.get("outputSchema")
+    runtime_rule = RUNTIME_ARGUMENT_RULES.get(name)
+    runtime_rule_lines = []
+    if runtime_rule is not None:
+        runtime_rule_lines = [f"- Runtime argument rule: {runtime_rule}"]
 
     return "\n".join(
         [
@@ -53,6 +65,7 @@ def _render_tool_section(tool: Tool) -> str:
             description,
             "",
             f"- Required input fields: {_format_required_fields(input_schema)}",
+            *runtime_rule_lines,
             "",
             "### Input Schema",
             "",

--- a/src/mgba_live_mcp/server.py
+++ b/src/mgba_live_mcp/server.py
@@ -239,15 +239,17 @@ async def list_tools() -> list[Tool]:
                         "description": "Optional explicit session id.",
                     },
                     "mgba_path": {"type": "string", "description": "Optional mGBA binary path."},
-                    "file": {"type": "string", "description": "Lua file path."},
-                    "code": {"type": "string", "description": "Inline Lua code."},
+                    "file": {
+                        "type": "string",
+                        "description": "Lua file path. Provide exactly one of file or code.",
+                    },
+                    "code": {
+                        "type": "string",
+                        "description": "Inline Lua code. Provide exactly one of file or code.",
+                    },
                     "timeout": {"type": "number", "default": 20.0},
                 },
                 "required": ["rom"],
-                "oneOf": [
-                    {"required": ["file"]},
-                    {"required": ["code"]},
-                ],
             },
         ),
         Tool(
@@ -265,15 +267,17 @@ async def list_tools() -> list[Tool]:
                         "description": "Optional explicit session id.",
                     },
                     "mgba_path": {"type": "string", "description": "Optional mGBA binary path."},
-                    "file": {"type": "string", "description": "Lua file path."},
-                    "code": {"type": "string", "description": "Inline Lua code."},
+                    "file": {
+                        "type": "string",
+                        "description": "Lua file path. Provide exactly one of file or code.",
+                    },
+                    "code": {
+                        "type": "string",
+                        "description": "Inline Lua code. Provide exactly one of file or code.",
+                    },
                     "timeout": {"type": "number", "default": 20.0},
                 },
                 "required": ["rom"],
-                "oneOf": [
-                    {"required": ["file"]},
-                    {"required": ["code"]},
-                ],
             },
         ),
         Tool(
@@ -282,14 +286,20 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "session": {"type": "string", "description": "Session id."},
-                    "pid": {"type": "integer", "description": "PID of a managed session."},
+                    "session": {
+                        "type": "string",
+                        "description": (
+                            "Session id. Provide session or pid (at least one required)."
+                        ),
+                    },
+                    "pid": {
+                        "type": "integer",
+                        "description": (
+                            "PID of a managed session. Provide session or pid (at least one)."
+                        ),
+                    },
                     "timeout": {"type": "number", "default": 20.0},
                 },
-                "anyOf": [
-                    {"required": ["session"]},
-                    {"required": ["pid"]},
-                ],
             },
         ),
         Tool(
@@ -298,14 +308,18 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "session": {"type": "string", "description": "Session id."},
-                    "all": {"type": "boolean", "description": "Whether to include all sessions."},
+                    "session": {
+                        "type": "string",
+                        "description": (
+                            "Session id for one session. Or set all=true for every session."
+                        ),
+                    },
+                    "all": {
+                        "type": "boolean",
+                        "description": "If true, list all sessions. Otherwise pass session.",
+                    },
                     "timeout": {"type": "number", "default": 20.0},
                 },
-                "anyOf": [
-                    {"required": ["session"]},
-                    {"required": ["all"], "properties": {"all": {"const": True}}},
-                ],
             },
         ),
         Tool(
@@ -340,15 +354,17 @@ async def list_tools() -> list[Tool]:
                 "type": "object",
                 "properties": {
                     "session": {"type": "string", "description": "Session id."},
-                    "file": {"type": "string", "description": "Lua file path."},
-                    "code": {"type": "string", "description": "Inline Lua code."},
+                    "file": {
+                        "type": "string",
+                        "description": "Lua file path. Provide exactly one of file or code.",
+                    },
+                    "code": {
+                        "type": "string",
+                        "description": "Inline Lua code. Provide exactly one of file or code.",
+                    },
                     "timeout": {"type": "number", "default": 20.0},
                 },
                 "required": ["session"],
-                "oneOf": [
-                    {"required": ["file"]},
-                    {"required": ["code"]},
-                ],
             },
         ),
         Tool(
@@ -358,15 +374,17 @@ async def list_tools() -> list[Tool]:
                 "type": "object",
                 "properties": {
                     "session": {"type": "string", "description": "Session id."},
-                    "file": {"type": "string", "description": "Lua file path."},
-                    "code": {"type": "string", "description": "Inline Lua code."},
+                    "file": {
+                        "type": "string",
+                        "description": "Lua file path. Provide exactly one of file or code.",
+                    },
+                    "code": {
+                        "type": "string",
+                        "description": "Inline Lua code. Provide exactly one of file or code.",
+                    },
                     "timeout": {"type": "number", "default": 20.0},
                 },
                 "required": ["session"],
-                "oneOf": [
-                    {"required": ["file"]},
-                    {"required": ["code"]},
-                ],
             },
         ),
         Tool(

--- a/src/mgba_live_mcp/server.py
+++ b/src/mgba_live_mcp/server.py
@@ -18,9 +18,44 @@ from .live_controller import LiveControllerClient
 server = Server("mgba-live-mcp")
 _controller = LiveControllerClient()
 
+_LUA_SOURCE_FILE_ARG = "file"
+_LUA_SOURCE_CODE_ARG = "code"
+_LUA_SOURCE_RUNTIME_RULE = (
+    f"Provide exactly one of `{_LUA_SOURCE_FILE_ARG}` or `{_LUA_SOURCE_CODE_ARG}`."
+)
+_ATTACH_RUNTIME_RULE = "Provide `session` or `pid`."
+_STATUS_RUNTIME_RULE = "Provide `session`, or set `all=true`."
+
+TOOL_RUNTIME_ARGUMENT_RULES = {
+    "mgba_live_start_with_lua": _LUA_SOURCE_RUNTIME_RULE,
+    "mgba_live_start_with_lua_and_view": _LUA_SOURCE_RUNTIME_RULE,
+    "mgba_live_attach": _ATTACH_RUNTIME_RULE,
+    "mgba_live_status": _STATUS_RUNTIME_RULE,
+    "mgba_live_run_lua": _LUA_SOURCE_RUNTIME_RULE,
+    "mgba_live_run_lua_and_view": _LUA_SOURCE_RUNTIME_RULE,
+}
+
 
 def _text_content(payload: Any) -> TextContent:
     return TextContent(type="text", text=json.dumps(payload, separators=(",", ":")))
+
+
+def _plain_argument_rule(rule: str) -> str:
+    return rule.replace("`", "")
+
+
+def _lua_source_properties() -> dict[str, dict[str, str]]:
+    rule = _plain_argument_rule(_LUA_SOURCE_RUNTIME_RULE)
+    return {
+        _LUA_SOURCE_FILE_ARG: {
+            "type": "string",
+            "description": f"Lua file path. {rule}",
+        },
+        _LUA_SOURCE_CODE_ARG: {
+            "type": "string",
+            "description": f"Inline Lua code. {rule}",
+        },
+    }
 
 
 def _text_payload(content: TextContent | ImageContent) -> dict[str, Any]:
@@ -138,15 +173,17 @@ def _parse_wait_frames(arguments: dict[str, Any]) -> int:
 
 
 def _lua_source_kwargs(arguments: dict[str, Any]) -> dict[str, Any]:
-    file_arg = arguments.get("file")
-    code_arg = arguments.get("code")
+    file_arg = arguments.get(_LUA_SOURCE_FILE_ARG)
+    code_arg = arguments.get(_LUA_SOURCE_CODE_ARG)
     has_file = bool(file_arg)
     has_code = bool(code_arg)
     if has_file == has_code:
-        raise ValueError("Exactly one of file or code is required.")
+        raise ValueError(
+            f"Exactly one of {_LUA_SOURCE_FILE_ARG} or {_LUA_SOURCE_CODE_ARG} is required."
+        )
     if has_file:
-        return {"file": str(file_arg)}
-    return {"code": str(code_arg)}
+        return {_LUA_SOURCE_FILE_ARG: str(file_arg)}
+    return {_LUA_SOURCE_CODE_ARG: str(code_arg)}
 
 
 def _build_start_kwargs(arguments: dict[str, Any]) -> dict[str, Any]:
@@ -239,14 +276,7 @@ async def list_tools() -> list[Tool]:
                         "description": "Optional explicit session id.",
                     },
                     "mgba_path": {"type": "string", "description": "Optional mGBA binary path."},
-                    "file": {
-                        "type": "string",
-                        "description": "Lua file path. Provide exactly one of file or code.",
-                    },
-                    "code": {
-                        "type": "string",
-                        "description": "Inline Lua code. Provide exactly one of file or code.",
-                    },
+                    **_lua_source_properties(),
                     "timeout": {"type": "number", "default": 20.0},
                 },
                 "required": ["rom"],
@@ -267,14 +297,7 @@ async def list_tools() -> list[Tool]:
                         "description": "Optional explicit session id.",
                     },
                     "mgba_path": {"type": "string", "description": "Optional mGBA binary path."},
-                    "file": {
-                        "type": "string",
-                        "description": "Lua file path. Provide exactly one of file or code.",
-                    },
-                    "code": {
-                        "type": "string",
-                        "description": "Inline Lua code. Provide exactly one of file or code.",
-                    },
+                    **_lua_source_properties(),
                     "timeout": {"type": "number", "default": 20.0},
                 },
                 "required": ["rom"],
@@ -288,15 +311,12 @@ async def list_tools() -> list[Tool]:
                 "properties": {
                     "session": {
                         "type": "string",
-                        "description": (
-                            "Session id. Provide session or pid (at least one required)."
-                        ),
+                        "description": f"Session id. {_plain_argument_rule(_ATTACH_RUNTIME_RULE)}",
                     },
                     "pid": {
                         "type": "integer",
-                        "description": (
-                            "PID of a managed session. Provide session or pid (at least one)."
-                        ),
+                        "description": "PID of a managed session. "
+                        f"{_plain_argument_rule(_ATTACH_RUNTIME_RULE)}",
                     },
                     "timeout": {"type": "number", "default": 20.0},
                 },
@@ -310,9 +330,8 @@ async def list_tools() -> list[Tool]:
                 "properties": {
                     "session": {
                         "type": "string",
-                        "description": (
-                            "Session id for one session. Or set all=true for every session."
-                        ),
+                        "description": "Session id for one session. "
+                        f"{_plain_argument_rule(_STATUS_RUNTIME_RULE)}",
                     },
                     "all": {
                         "type": "boolean",
@@ -354,14 +373,7 @@ async def list_tools() -> list[Tool]:
                 "type": "object",
                 "properties": {
                     "session": {"type": "string", "description": "Session id."},
-                    "file": {
-                        "type": "string",
-                        "description": "Lua file path. Provide exactly one of file or code.",
-                    },
-                    "code": {
-                        "type": "string",
-                        "description": "Inline Lua code. Provide exactly one of file or code.",
-                    },
+                    **_lua_source_properties(),
                     "timeout": {"type": "number", "default": 20.0},
                 },
                 "required": ["session"],
@@ -374,14 +386,7 @@ async def list_tools() -> list[Tool]:
                 "type": "object",
                 "properties": {
                     "session": {"type": "string", "description": "Session id."},
-                    "file": {
-                        "type": "string",
-                        "description": "Lua file path. Provide exactly one of file or code.",
-                    },
-                    "code": {
-                        "type": "string",
-                        "description": "Inline Lua code. Provide exactly one of file or code.",
-                    },
+                    **_lua_source_properties(),
                     "timeout": {"type": "number", "default": 20.0},
                 },
                 "required": ["session"],

--- a/tests/test_mcp_reference_docs.py
+++ b/tests/test_mcp_reference_docs.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+from mgba_live_mcp import server as mcp_server
+
+
+def _load_generate_mcp_reference() -> ModuleType:
+    script = Path(__file__).resolve().parents[1] / "scripts" / "generate_mcp_reference.py"
+    spec = importlib.util.spec_from_file_location("generate_mcp_reference", script)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_reference_uses_server_runtime_argument_rules() -> None:
+    generate_mcp_reference = _load_generate_mcp_reference()
+    assert not hasattr(generate_mcp_reference, "RUNTIME_ARGUMENT_RULES")
+
+    tools = asyncio.run(mcp_server.list_tools())
+    run_lua = next(tool for tool in tools if tool.name == "mgba_live_run_lua")
+
+    rendered = generate_mcp_reference._render_tool_section(run_lua)
+
+    runtime_rule = mcp_server.TOOL_RUNTIME_ARGUMENT_RULES[run_lua.name]
+    assert f"- Runtime argument rule: {runtime_rule}" in rendered

--- a/tests/test_v2_server_contract.py
+++ b/tests/test_v2_server_contract.py
@@ -197,36 +197,19 @@ class _FakeController:
 def test_list_tools_exposes_v2_visual_tools() -> None:
     tools = asyncio.run(mcp_server.list_tools())
     names = {tool.name for tool in tools}
-    by_name = {tool.name: tool for tool in tools}
 
     assert "mgba_live_get_view" in names
     assert "mgba_live_run_lua_and_view" in names
     assert "mgba_live_input_tap_and_view" in names
     assert "mgba_live_start_with_lua_and_view" in names
-    assert by_name["mgba_live_attach"].inputSchema["anyOf"] == [
-        {"required": ["session"]},
-        {"required": ["pid"]},
-    ]
-    assert by_name["mgba_live_status"].inputSchema["anyOf"] == [
-        {"required": ["session"]},
-        {"required": ["all"], "properties": {"all": {"const": True}}},
-    ]
-    assert by_name["mgba_live_run_lua"].inputSchema["oneOf"] == [
-        {"required": ["file"]},
-        {"required": ["code"]},
-    ]
-    assert by_name["mgba_live_run_lua_and_view"].inputSchema["oneOf"] == [
-        {"required": ["file"]},
-        {"required": ["code"]},
-    ]
-    assert by_name["mgba_live_start_with_lua"].inputSchema["oneOf"] == [
-        {"required": ["file"]},
-        {"required": ["code"]},
-    ]
-    assert by_name["mgba_live_start_with_lua_and_view"].inputSchema["oneOf"] == [
-        {"required": ["file"]},
-        {"required": ["code"]},
-    ]
+    # Strict function-calling clients reject top-level JSON Schema combinators.
+    forbidden_top = ("oneOf", "anyOf", "allOf", "not", "enum")
+    for tool in tools:
+        schema = tool.inputSchema
+        assert isinstance(schema, dict), f"{tool.name}: inputSchema must be an object schema"
+        assert schema.get("type") == "object", f"{tool.name}: inputSchema type must be object"
+        bad = [k for k in forbidden_top if k in schema]
+        assert not bad, f"{tool.name}: inputSchema must not use top-level {bad}"
 
 
 def test_status_requires_session_unless_all(monkeypatch: Any) -> None:

--- a/tests/test_v2_server_contract.py
+++ b/tests/test_v2_server_contract.py
@@ -227,6 +227,39 @@ def test_status_requires_session_unless_all(monkeypatch: Any) -> None:
     assert "screenshot" not in payload
 
 
+def test_attach_requires_session_or_pid(monkeypatch: Any) -> None:
+    monkeypatch.setattr(mcp_server, "_controller", _FakeController())
+
+    with pytest.raises(ValueError, match="session_required"):
+        asyncio.run(mcp_server.call_tool("mgba_live_attach", {}))
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "base_args"),
+    [
+        ("mgba_live_start_with_lua", {"rom": "/tmp/game.gba"}),
+        ("mgba_live_start_with_lua_and_view", {"rom": "/tmp/game.gba"}),
+        ("mgba_live_run_lua", {"session": "session-123"}),
+        ("mgba_live_run_lua_and_view", {"session": "session-123"}),
+    ],
+)
+def test_lua_tools_require_exactly_one_source(
+    monkeypatch: Any, tool_name: str, base_args: dict[str, Any]
+) -> None:
+    monkeypatch.setattr(mcp_server, "_controller", _FakeController())
+
+    with pytest.raises(ValueError, match="Exactly one of file or code"):
+        asyncio.run(mcp_server.call_tool(tool_name, dict(base_args)))
+
+    with pytest.raises(ValueError, match="Exactly one of file or code"):
+        asyncio.run(
+            mcp_server.call_tool(
+                tool_name,
+                {**base_args, "file": "/tmp/script.lua", "code": "return true"},
+            )
+        )
+
+
 def test_single_session_tools_require_session(monkeypatch: Any) -> None:
     monkeypatch.setattr(mcp_server, "_controller", _FakeController())
 


### PR DESCRIPTION
## Summary
- remove top-level JSON Schema combinators from MCP tool input schemas so strict function-calling clients accept the tool list
- preserve runtime validation for session/pid and file/code requirements in call handling
- update the v2 contract test and regenerate the MCP reference docs

## Root Cause
Strict function-calling clients reject MCP tool schemas that put oneOf/anyOf/allOf/enum/not at the top level. mgba_live_attach exposed top-level anyOf, and Lua/status tools exposed similar conditional schema shapes.

## Validation
- make check