### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.5.0
+
+- Remove top-level JSON Schema combinators from MCP tool input schemas so
+  strict function-calling clients can load the tool list.
+- Preserve runtime validation for conditional arguments, including
+  `session`/`pid` attach targets and Lua `file`/`code` source selection.
+- Update generated MCP reference docs with runtime argument notes sourced from
+  the server metadata.
+
 ## 0.4.0
 
 - Hard-cut the MCP contract to explicit session scoping for single-session

--- a/README.md
+++ b/README.md
@@ -245,11 +245,11 @@ make check
 
 ## Release Checklist
 
-1. Confirm version is `0.4.0` in `pyproject.toml` and `src/mgba_live_mcp/__init__.py`.
+1. Confirm version is `0.5.0` in `pyproject.toml` and `src/mgba_live_mcp/__init__.py`.
 2. Add release notes in `CHANGELOG.md`.
 3. Run local checks:
 `uv sync --group dev && make check && uv build`
 4. Trigger TestPyPI publish workflow (`publish-testpypi`) and verify install from TestPyPI.
-5. Push tag `v0.4.0` to trigger the PyPI release workflow.
+5. Push tag `v0.5.0` to trigger the PyPI release workflow.
 6. Smoke test:
 `uvx mgba-live-mcp` and `uvx --from git+https://github.com/penandlim/mgba-live-mcp mgba-live-mcp`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mgba-live-mcp"
-version = "0.4.0"
+version = "0.5.0"
 description = "MCP server for persistent live mGBA control with script bridge, screenshots, memory and input tooling"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/mgba_live_mcp/__init__.py
+++ b/src/mgba_live_mcp/__init__.py
@@ -1,3 +1,3 @@
 """mGBA live MCP package."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/uv.lock
+++ b/uv.lock
@@ -450,7 +450,7 @@ wheels = [
 
 [[package]]
 name = "mgba-live-mcp"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
## Summary
- bump package metadata and lockfile to 0.5.0
- add 0.5.0 changelog notes for the strict tool-schema compatibility fix
- update release checklist tag/version references

## Validation
- uv sync --group dev && make check && uv build